### PR TITLE
Remove duplicate zero-ing of empty disk space

### DIFF
--- a/script/cleanup.sh
+++ b/script/cleanup.sh
@@ -66,10 +66,6 @@ if [ "x${swapuuid}" != "x" ]; then
     /sbin/mkswap -U "${swapuuid}" "${swappart}"
 fi
 
-# Zero out the free space to save space in the final image
-dd if=/dev/zero of=/EMPTY bs=1M || echo "dd exit code $? is suppressed"
-rm -f /EMPTY
-
 # Make sure we wait until all the data is written to disk, otherwise
 # Packer might quite too early
 sync

--- a/script/cleanup.sh
+++ b/script/cleanup.sh
@@ -38,12 +38,14 @@ echo "==> Clearing last login information"
 >/var/log/btmp
 
 # Whiteout root
+echo '==> Clear out root fs'
 count=$(df --sync -kP / | tail -n1  | awk -F ' ' '{print $4}')
 let count--
 dd if=/dev/zero of=/tmp/whitespace bs=1024 count=$count
 rm /tmp/whitespace
 
 # Whiteout /boot
+echo '==> Clear out /boot'
 count=$(df --sync -kP /boot | tail -n1 | awk -F ' ' '{print $4}')
 let count--
 dd if=/dev/zero of=/boot/whitespace bs=1024 count=$count


### PR DESCRIPTION
Zero-ing root fs and /boot is already done earlier, so this second run is useless and takes a lot of time.
