### PR TITLE
Updated ISO-urls

### DIFF
--- a/debian82-i386.json
+++ b/debian82-i386.json
@@ -6,7 +6,7 @@
   "iso_checksum": "5f2a45bce80d9ebd0db7cde3cbee10d32554a495",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-8.2.0-i386-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/release/8.2.0/i386/iso-dvd/debian-8.2.0-i386-DVD-1.iso",
+  "iso_url": "http://debian.nctu.edu.tw/debian-cd/8.2.0/i386/iso-dvd/debian-8.2.0-i386-DVD-1.iso",
   "memory": "512",
   "preseed": "preseed-jessie.cfg",
   "virtualbox_guest_os_type": "Debian",

--- a/debian82.json
+++ b/debian82.json
@@ -6,7 +6,7 @@
   "iso_checksum": "40f51a36b39c180fe46d7393e5a3a3985072ffc2",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-8.2.0-amd64-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/release/8.2.0/amd64/iso-dvd/debian-8.2.0-amd64-DVD-1.iso",
+  "iso_url": "http://debian.nctu.edu.tw/debian-cd/8.2.0/amd64/iso-dvd/debian-8.2.0-amd64-DVD-1.iso",
   "memory": "512",
   "preseed" : "preseed-jessie.cfg"
 }

--- a/debian83-i386.json
+++ b/debian83-i386.json
@@ -6,7 +6,7 @@
   "iso_checksum": "cf958ba477074c7352ad5436865b7b149370cabd",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-8.3.0-i386-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/release/8.3.0/i386/iso-dvd/debian-8.3.0-i386-DVD-1.iso",
+  "iso_url": "http://debian.nctu.edu.tw/debian-cd/8.3.0/i386/iso-dvd/debian-8.3.0-i386-DVD-1.iso",
   "memory": "512",
   "preseed": "preseed-jessie.cfg",
   "virtualbox_guest_os_type": "Debian",

--- a/debian83.json
+++ b/debian83.json
@@ -6,7 +6,7 @@
   "iso_checksum": "aac35cc1315c922326b3adb3e7d21a7e3bfd80ef",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-8.3.0-amd64-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/release/8.3.0/amd64/iso-dvd/debian-8.3.0-amd64-DVD-1.iso",
+  "iso_url": "http://debian.nctu.edu.tw/debian-cd/8.3.0/amd64/iso-dvd/debian-8.3.0-amd64-DVD-1.iso",
   "memory": "512",
   "preseed" : "preseed-jessie.cfg"
 }

--- a/debian84-i386.json
+++ b/debian84-i386.json
@@ -6,7 +6,7 @@
   "iso_checksum": "42fea1a368ffacba2de240a261285006a8e9df27",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-8.4.0-i386-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/release/8.4.0/i386/iso-dvd/debian-8.4.0-i386-DVD-1.iso",
+  "iso_url": "http://cdimage.debian.org/cdimage/archive/8.4.0/i386/iso-dvd/debian-8.4.0-i386-DVD-1.iso",
   "memory": "512",
   "preseed": "preseed-jessie.cfg",
   "virtualbox_guest_os_type": "Debian",

--- a/debian84.json
+++ b/debian84.json
@@ -6,7 +6,7 @@
   "iso_checksum": "2fc02fb311374e211d2cb8d56a603a241cec47dd",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-8.4.0-amd64-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/release/8.4.0/amd64/iso-dvd/debian-8.4.0-amd64-DVD-1.iso",
+  "iso_url": "http://cdimage.debian.org/cdimage/archive/8.4.0/amd64/iso-dvd/debian-8.4.0-amd64-DVD-1.iso",
   "memory": "512",
   "preseed" : "preseed-jessie.cfg"
 }


### PR DESCRIPTION
I've updated the 8.4 ISO url to use the archive-path in the official Debian-CD repository.

Everything prior to 8.4 is only available as jigdo in the official Debian-CD repository. I've found a taiwan mirror, that (still?) holds the ISOs, but I've only updated 8.2 and 8.3.
