### PR TITLE
Use jigdo to aquire iso images

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ in your favourite CI tool:
     make deliver # Upload box artifacts to a repository
     make clean   # Clean up build detritus
 
+### Aquiring ISO Images
+
+The ISO image are expected to be in the iso subdirectory or the user configured
+path. The easiest way to aquire the files is the Makefile which depends on [jigdo-lite](https://www.debian.org/CD/jigdo-cd/).
+
+For a single iso:
+  make iso/debian-7.8.0-amd64-DVD-1.iso
+
+For all isos:
+  make isos
+
 ### Proxy Settings
 
 The templates respect the following network proxy environment variables

--- a/debian.json
+++ b/debian.json
@@ -171,7 +171,7 @@
     "iso_checksum_type": "sha1",
     "iso_name": "debian-8.2.0-amd64-DVD-1.iso",
     "iso_path": "/Volumes/Thunder/software/debian",
-    "iso_url": "http://cdimage.debian.org/cdimage/release/8.2.0/amd64/iso-dvd/debian-8.2.0-amd64-DVD-1.iso",
+    "iso_url": "iso/debian-8.2.0-amd64-DVD-1.iso",
     "memory": "512",
     "no_proxy": "{{env `no_proxy`}}",
     "parallels_guest_os_type": "debian",

--- a/debian78-i386.json
+++ b/debian78-i386.json
@@ -6,7 +6,7 @@
   "iso_checksum": "1eaf2442354052f7b12ec481abddd5e56698137d",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-7.8.0-i386-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/archive/7.8.0/i386/iso-dvd/debian-7.8.0-i386-DVD-1.iso",
+  "iso_url": "iso/debian-7.8.0-i386-DVD-1.iso",
   "memory": "512",
   "preseed": "preseed-jessie.cfg",
   "virtualbox_guest_os_type": "Debian",

--- a/debian78.json
+++ b/debian78.json
@@ -6,7 +6,7 @@
   "iso_checksum": "ff9543a5ea691d80a5281ebb21a3fe6e1eba1246",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-7.8.0-amd64-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/archive/7.8.0/amd64/iso-dvd/debian-7.8.0-amd64-DVD-1.iso",
+  "iso_url": "iso/debian-7.8.0-amd64-DVD-1.iso",
   "memory": "512",
   "preseed" : "preseed-jessie.cfg",
   "vmware_guest_os_type": "debian7-64"

--- a/debian79-i386.json
+++ b/debian79-i386.json
@@ -6,7 +6,7 @@
   "iso_checksum": "778e228f43edb3b20e5645bd59830e965a77f53a",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-7.9.0-i386-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/archive/7.9.0/i386/iso-dvd/debian-7.9.0-i386-DVD-1.iso",
+  "iso_url": "iso/debian-7.9.0-i386-DVD-1.iso",
   "memory": "512",
   "preseed": "preseed-jessie.cfg",
   "virtualbox_guest_os_type": "Debian",

--- a/debian79.json
+++ b/debian79.json
@@ -6,7 +6,7 @@
   "iso_checksum": "e15f8eaeae60f3e75ed1e775c432ec7d8fa3c04a",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-7.9.0-amd64-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/archive/7.9.0/amd64/iso-dvd/debian-7.9.0-amd64-DVD-1.iso",
+  "iso_url": "iso/debian-7.9.0-amd64-DVD-1.iso",
   "memory": "512",
   "preseed" : "preseed-jessie.cfg",
   "vmware_guest_os_type": "debian7-64"

--- a/debian80-i386.json
+++ b/debian80-i386.json
@@ -6,7 +6,7 @@
   "iso_checksum": "734490cf7db1a9295b93faab01d0a02aafa04af9",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-8.0.0-i386-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/archive/8.0.0/i386/iso-dvd/debian-8.0.0-i386-DVD-1.iso",
+  "iso_url": "iso/debian-8.0.0-i386-DVD-1.iso",
   "memory": "512",
   "preseed": "preseed-jessie.cfg",
   "virtualbox_guest_os_type": "Debian",

--- a/debian80.json
+++ b/debian80.json
@@ -6,7 +6,7 @@
   "iso_checksum": "95c1ad2410e436382119bf97d263c94b654d4942",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-8.0.0-amd64-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/archive/8.0.0/amd64/iso-dvd/debian-8.0.0-amd64-DVD-1.iso",
+  "iso_url": "iso/debian-8.0.0-amd64-DVD-1.iso",
   "memory": "512",
   "preseed" : "preseed-jessie.cfg"
 }

--- a/debian81-i386.json
+++ b/debian81-i386.json
@@ -6,7 +6,7 @@
   "iso_checksum": "e09b8f1e39b0e187734f6501d6298d860989f189",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-8.1.0-i386-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/archive/8.1.0/i386/iso-dvd/debian-8.1.0-i386-DVD-1.iso",
+  "iso_url": "iso/debian-8.1.0-i386-DVD-1.iso",
   "memory": "512",
   "preseed": "preseed-jessie.cfg",
   "virtualbox_guest_os_type": "Debian",

--- a/debian81.json
+++ b/debian81.json
@@ -6,7 +6,7 @@
   "iso_checksum": "018ac2307ca33f021ee33ac9e26f05c7a47eb0e2",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-8.1.0-amd64-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/archive/8.1.0/amd64/iso-dvd/debian-8.1.0-amd64-DVD-1.iso",
+  "iso_url": "iso/debian-8.1.0-amd64-DVD-1.iso",
   "memory": "512",
   "preseed" : "preseed-jessie.cfg"
 }

--- a/debian82-i386.json
+++ b/debian82-i386.json
@@ -6,7 +6,7 @@
   "iso_checksum": "5f2a45bce80d9ebd0db7cde3cbee10d32554a495",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-8.2.0-i386-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/release/8.2.0/i386/iso-dvd/debian-8.2.0-i386-DVD-1.iso",
+  "iso_url": "iso/debian-8.2.0-i386-DVD-1.iso",
   "memory": "512",
   "preseed": "preseed-jessie.cfg",
   "virtualbox_guest_os_type": "Debian",

--- a/debian82.json
+++ b/debian82.json
@@ -6,7 +6,7 @@
   "iso_checksum": "40f51a36b39c180fe46d7393e5a3a3985072ffc2",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-8.2.0-amd64-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/release/8.2.0/amd64/iso-dvd/debian-8.2.0-amd64-DVD-1.iso",
+  "iso_url": "iso/debian-8.2.0-amd64-DVD-1.iso",
   "memory": "512",
   "preseed" : "preseed-jessie.cfg"
 }

--- a/debian83-i386.json
+++ b/debian83-i386.json
@@ -6,7 +6,7 @@
   "iso_checksum": "cf958ba477074c7352ad5436865b7b149370cabd",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-8.3.0-i386-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/release/8.3.0/i386/iso-dvd/debian-8.3.0-i386-DVD-1.iso",
+  "iso_url": "iso/debian-8.3.0-i386-DVD-1.iso",
   "memory": "512",
   "preseed": "preseed-jessie.cfg",
   "virtualbox_guest_os_type": "Debian",

--- a/debian83.json
+++ b/debian83.json
@@ -6,7 +6,7 @@
   "iso_checksum": "aac35cc1315c922326b3adb3e7d21a7e3bfd80ef",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-8.3.0-amd64-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/release/8.3.0/amd64/iso-dvd/debian-8.3.0-amd64-DVD-1.iso",
+  "iso_url": "iso/debian-8.3.0-amd64-DVD-1.iso",
   "memory": "512",
   "preseed" : "preseed-jessie.cfg"
 }

--- a/debian84-i386.json
+++ b/debian84-i386.json
@@ -6,7 +6,7 @@
   "iso_checksum": "42fea1a368ffacba2de240a261285006a8e9df27",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-8.4.0-i386-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/release/8.4.0/i386/iso-dvd/debian-8.4.0-i386-DVD-1.iso",
+  "iso_url": "iso/debian-8.4.0-i386-DVD-1.iso",
   "memory": "512",
   "preseed": "preseed-jessie.cfg",
   "virtualbox_guest_os_type": "Debian",

--- a/debian84.json
+++ b/debian84.json
@@ -6,7 +6,7 @@
   "iso_checksum": "2fc02fb311374e211d2cb8d56a603a241cec47dd",
   "iso_checksum_type": "sha1",
   "iso_name": "debian-8.4.0-amd64-DVD-1.iso",
-  "iso_url": "http://cdimage.debian.org/cdimage/release/8.4.0/amd64/iso-dvd/debian-8.4.0-amd64-DVD-1.iso",
+  "iso_url": "iso/debian-8.4.0-amd64-DVD-1.iso",
   "memory": "512",
   "preseed" : "preseed-jessie.cfg"
 }


### PR DESCRIPTION
This PR adds Makefile tasks to fetch the iso images via jigdo into the local directory "iso" and uses this directory instead of http urls.

Related: #21 #34 
