### PR TITLE
make sure udev overrides persist package updates

### DIFF
--- a/script/cleanup.sh
+++ b/script/cleanup.sh
@@ -4,7 +4,8 @@
 # http://6.ptmc.org/?p=164
 echo "cleaning up udev rules"
 rm -rf /dev/.udev/
-rm /lib/udev/rules.d/75-persistent-net-generator.rules
+# Better fix that persists package updates: http://serverfault.com/a/485689
+touch /etc/udev/rules.d/75-persistent-net-generator.rules
 
 echo "==> Cleaning up leftover dhcp leases"
 if [ -d "/var/lib/dhcp" ]; then


### PR DESCRIPTION
updates to the `udev` package could reinstate the removed file.

As per the referenced ServerFault answer, the "correct" way to prevent a udev rule from running is to place a replacement file in the `/etc/udev/rules.d/` directory.