### PR TITLE
Make doc removal configurable

### DIFF
--- a/debian.json
+++ b/debian.json
@@ -177,6 +177,7 @@
     "parallels_guest_os_type": "debian",
     "preseed": "preseed-jessie.cfg",
     "rsync_proxy": "{{env `rsync_proxy`}}",
+    "remove_docs": "true",
     "ssh_password": "vagrant",
     "ssh_username": "vagrant",
     "update": "false",

--- a/debian.json
+++ b/debian.json
@@ -131,6 +131,7 @@
     {
       "environment_vars": [
         "DESKTOP={{user `desktop`}}",
+        "REMOVE_DOCS={{user `remove_docs`}}",
         "UPDATE={{user `update`}}",
         "INSTALL_VAGRANT_KEY={{user `install_vagrant_key`}}",
         "SSH_USERNAME={{user `ssh_username`}}",

--- a/script/minimize.sh
+++ b/script/minimize.sh
@@ -20,8 +20,12 @@ echo "==> Removing linux source"
 dpkg --list | awk '{ print $2 }' | grep linux-source | xargs apt-get -y purge
 echo "==> Removing development packages"
 dpkg --list | awk '{ print $2 }' | grep -- '-dev$' | xargs apt-get -y purge
-echo "==> Removing documentation"
-dpkg --list | awk '{ print $2 }' | grep -- '-doc$' | xargs apt-get -y purge
+
+if [[ "$REMOVE_DOCS" =~ ^(true|yes|on|1|TRUE|YES|ON])$ ]]; then
+	echo "==> Removing documentation"
+	dpkg --list | awk '{ print $2 }' | grep -- '-doc$' | xargs apt-get -y purge
+fi
+
 apt-get -y purge build-essential
 echo "==> Removing X11 libraries"
 apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6
@@ -43,16 +47,22 @@ apt-get -y autoremove --purge
 apt-get -y autoclean
 apt-get -y clean
 
-echo "==> Removing man pages"
-find /usr/share/man -type f -delete
 echo "==> Removing APT files"
 find /var/lib/apt -type f -delete
-echo "==> Removing any docs"
-find /usr/share/doc -type f -delete
+
+if [[ "$REMOVE_DOCS" =~ ^(true|yes|on|1|TRUE|YES|ON])$ ]]; then
+	echo "==> Removing man pages"
+	find /usr/share/man -type f -delete
+	echo "==> Removing any docs"
+	find /usr/share/doc -type f -delete
+	echo "==> Removing info"
+	rm -rf /usr/share/info/*
+fi
+
 echo "==> Removing caches"
 find /var/cache -type f -delete
-echo "==> Removing groff info lintian linda"
-rm -rf /usr/share/groff/* /usr/share/info/* /usr/share/lintian/* /usr/share/linda/*
+echo "==> Removing lintian linda"
+rm -rf /usr/share/lintian/* /usr/share/linda/*
 
 echo "==> Disk usage after cleanup"
 df -h


### PR DESCRIPTION
Having man/info/doc pages available can be quite helpful in development situations. This change makes the removal of such files configurable.

Additionally, this change stops removing groff files, as man is unusable with the files missing.