### PR TITLE
Fix systemd ssh hang

### DIFF
--- a/debian.json
+++ b/debian.json
@@ -144,6 +144,7 @@
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
         "script/remove-cdrom-sources.sh",
+        "script/systemd.sh",
         "script/update.sh",
         "script/desktop.sh",
         "script/vagrant.sh",

--- a/script/systemd.sh
+++ b/script/systemd.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -eux
+
+if dpkg-query -W -f='${Status}' systemd 2>/dev/null | cut -f 3 -d ' ' | grep -q '^installed$'; then
+	echo "==> Installing PAM module for systemd to prevent Vagrant/SSH hangs"
+	apt-get -y install libpam-systemd
+fi

--- a/script/vagrant.sh
+++ b/script/vagrant.sh
@@ -33,7 +33,7 @@ if [ "$INSTALL_VAGRANT_KEY" = "true" ] || [ "$INSTALL_VAGRANT_KEY" = "1" ]; then
     chown -R $SSH_USER:$SSH_USER $SSH_USER_HOME/.ssh
 fi
 
-if dpkg-query -W -f='${Status}\n' systemd 2>/dev/null | cut -f 3 -d ' ' | grep -q '^installed$'; then
+if dpkg-query -W -f='${Status}' systemd 2>/dev/null | cut -f 3 -d ' ' | grep -q '^installed$'; then
 	echo "==> Installing PAM module for systemd to prevent Vagrant/SSH hangs"
 	apt-get -y install libpam-systemd
 fi

--- a/script/vagrant.sh
+++ b/script/vagrant.sh
@@ -32,3 +32,8 @@ if [ "$INSTALL_VAGRANT_KEY" = "true" ] || [ "$INSTALL_VAGRANT_KEY" = "1" ]; then
     chmod 600 $SSH_USER_HOME/.ssh/authorized_keys
     chown -R $SSH_USER:$SSH_USER $SSH_USER_HOME/.ssh
 fi
+
+if dpkg-query -W -f='${Status}\n' systemd 2>/dev/null | cut -f 3 -d ' ' | grep -q '^installed$'; then
+	echo "==> Installing PAM module for systemd to prevent Vagrant/SSH hangs"
+	apt-get -y install libpam-systemd
+fi

--- a/script/vagrant.sh
+++ b/script/vagrant.sh
@@ -32,8 +32,3 @@ if [ "$INSTALL_VAGRANT_KEY" = "true" ] || [ "$INSTALL_VAGRANT_KEY" = "1" ]; then
     chmod 600 $SSH_USER_HOME/.ssh/authorized_keys
     chown -R $SSH_USER:$SSH_USER $SSH_USER_HOME/.ssh
 fi
-
-if dpkg-query -W -f='${Status}' systemd 2>/dev/null | cut -f 3 -d ' ' | grep -q '^installed$'; then
-	echo "==> Installing PAM module for systemd to prevent Vagrant/SSH hangs"
-	apt-get -y install libpam-systemd
-fi


### PR DESCRIPTION
Debian w/ systemd hangs SSH connections on reboot/shutdown if the PAM systemd module is not installed. This resolves that in the base box.