### PR TITLE
Fix provisioning reboot hang

### DIFF
--- a/debian.json
+++ b/debian.json
@@ -155,7 +155,8 @@
         "script/minimize.sh",
         "script/cleanup.sh"
       ],
-      "type": "shell"
+      "type": "shell",
+      "pause_before": "10s"
     }
   ],
   "variables": {

--- a/script/update.sh
+++ b/script/update.sh
@@ -8,5 +8,5 @@ if [[ $UPDATE  =~ true || $UPDATE =~ 1 || $UPDATE =~ yes ]]; then
     echo "==> Performing dist-upgrade (all packages and kernel)"
     apt-get -y dist-upgrade --force-yes
     ifdown --all
-    reboot
+    shutdown -r now
 fi

--- a/script/update.sh
+++ b/script/update.sh
@@ -7,6 +7,6 @@ if [[ $UPDATE  =~ true || $UPDATE =~ 1 || $UPDATE =~ yes ]]; then
 
     echo "==> Performing dist-upgrade (all packages and kernel)"
     apt-get -y dist-upgrade --force-yes
+    ifdown --all
     reboot
-    sleep 60
 fi


### PR DESCRIPTION
Rebooting does not always automatically close the SSH connection `packer` uses to control the guest during box creation, leading to hangs when a reboot is required (i.e. when `update=true`).

This change should resolve that issue.