### PR TITLE
Add support for Packer 1.1: set expect_disconnect to true.

### DIFF
--- a/debian.json
+++ b/debian.json
@@ -158,7 +158,8 @@
         "script/cleanup.sh"
       ],
       "type": "shell",
-      "pause_before": "10s"
+      "pause_before": "10s",
+      "expect_disconnect": "true"
     }
   ],
   "variables": {


### PR DESCRIPTION
Otherwise update.sh will fail because the reboot disconnects and then packer bails out (see https://github.com/hashicorp/packer/blob/master/CHANGELOG.md#backwards-incompatibilities).