### PR TITLE
Added net-tools to preseed-jessie.cfg

### DIFF
--- a/http/preseed-jessie.cfg
+++ b/http/preseed-jessie.cfg
@@ -61,7 +61,7 @@ d-i grub-installer/only_debian boolean true
 d-i grub-installer/bootdev string default
 # Turn off last message about the install being complete
 d-i finish-install/reboot_in_progress note
-d-i pkgsel/include string openssh-server ntp curl nfs-common linux-headers-$(uname -r) build-essential perl dkms
+d-i pkgsel/include string openssh-server ntp curl nfs-common linux-headers-$(uname -r) build-essential perl dkms net-tools
 # This first command is run as early as possible, just after
 # preseeding is read.
 # Prevent packaged version of VirtualBox Guest Additions being installed:


### PR DESCRIPTION
VMware tools still looks for ifconfig to do configuration.  Debian 9 doesn't have it by default so adding `net-tools` allows vmware box to be built. Closes #64 